### PR TITLE
chore: remove ssh reachability checks and reindent mkdocs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,3 +1,4 @@
+---
 site_name: Symplegma
 site_description: Website and documentation for symplegma project
 site_author: ArchiFleKs
@@ -46,15 +47,15 @@ markdown_extensions:
 nav:
   - Overview: index.md
   - Documentation:
-    - Kubernetes:
-      - Kubeadm: configuration/kubeadm/kubeadm.md
-    - OS:
-      - Ubuntu: configuration/os/ubuntu.md
-      - CoreOS: configuration/os/coreos.md
-    - Networking:
-      - Calico: configuration/networking/calico.md
-      - HA: configuration/networking/ha.md
+      - Kubernetes:
+          - Kubeadm: configuration/kubeadm/kubeadm.md
+      - OS:
+          - Ubuntu: configuration/os/ubuntu.md
+          - CoreOS: configuration/os/coreos.md
+      - Networking:
+          - Calico: configuration/networking/calico.md
+          - HA: configuration/networking/ha.md
   - User Guides:
-    - Bare-Metal: user-guides/bare-metal.md
-    - AWS: user-guides/aws.md
-    - OpenStack: user-guides/openstack.md
+      - Bare-Metal: user-guides/bare-metal.md
+      - AWS: user-guides/aws.md
+      - OpenStack: user-guides/openstack.md

--- a/symplegma-upgrade.yml
+++ b/symplegma-upgrade.yml
@@ -1,10 +1,6 @@
 ---
 - hosts: all
   gather_facts: false
-  pre_tasks:
-    - name: Wait for port 22 to be ready
-      local_action: wait_for port=22 host="{{ ansible_host }}" search_regex=OpenSSH delay=10
-      become: false
   roles:
     - symplegma-os_bootstrap
   tags:


### PR DESCRIPTION
- Removing deprecated `local_action` and replacing with `delegate_to: localhost` for ansible-lint
- Fix some indentation issues for yamllint

EDIT: just removing ssh checks as asked