### PR TITLE
fix: Link documentation to gh page mkdocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The main goal is to be minimalist with sensible defaults.
 
 ## Documentation
 
-Documentation can be found [here](https://clusterfrak-dynamics.github.io/symplegma/)
+Documentation can be found [here](https://particuleio.github.io/symplegma/)
 
 ## Roadmap
 


### PR DESCRIPTION
Point to the CI-generated documentation's website