### PR TITLE
chore(ci): clone symplegma roles before generating mkdocs

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -1,24 +1,36 @@
+---
 name: 'symplegma:mkdocs'
 
-on:
+'on':
   push:
     branches:
-    - main
+      - main
     paths:
-    - 'docs/**'
-    - 'mkdocs.yml'
-    - 'README.md'
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'README.md'
 
 jobs:
   terraform:
     name: 'symplegma:mkdocs'
     runs-on: ubuntu-latest
     steps:
-    - name: checkout
-      uses: actions/checkout@v2
+      - name: checkout
+        uses: actions/checkout@v2
 
-    - name: deploy
-      uses: mhausenblas/mkdocs-deploy-gh-pages@master
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        REQUIREMENTS: docs/requirements.txt
+      - name: set up python3
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: install ansible
+        run: pip3 install ansible
+
+      - name: install symplegma roles
+        run: ansible-galaxy install -r requirements.yml
+
+      - name: deploy
+        uses: mhausenblas/mkdocs-deploy-gh-pages@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REQUIREMENTS: docs/requirements.txt

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -9,6 +9,13 @@ name: 'symplegma:mkdocs'
       - 'docs/**'
       - 'mkdocs.yml'
       - 'README.md'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'README.md'
 
 jobs:
   terraform:
@@ -30,6 +37,7 @@ jobs:
         run: ansible-galaxy install -r requirements.yml
 
       - name: deploy
+        if: github.ref == 'refs/heads/main'
         uses: mhausenblas/mkdocs-deploy-gh-pages@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Allow to reference role content in symplegma documentation by cloning the roles before running the `deploy` step.
- Trigger mkdocs workflow on PRs to `main`
- Deploy only on push to `main`

extra: lint Github Action file 