### PR TITLE
fix(deps-main): add missing symplegma-crio role

### DIFF
--- a/requirements-main.yml
+++ b/requirements-main.yml
@@ -15,6 +15,10 @@
   scm: git
   src: https://github.com/particuleio/symplegma-containerd
   version: main
+- name: symplegma-crio
+  scm: git
+  src: https://github.com/particuleio/symplegma-crio
+  version: main
 - name: symplegma-cni
   scm: git
   src: https://github.com/particuleio/symplegma-cni


### PR DESCRIPTION
Add [`symplegma-crio`](https://github.com/particuleio/symplegma-crio) role dependency to requirements-main.yml.

Fresh install from `main` is breaking on `symplegma-init` playbook run if the role is missing.