### PR TITLE
fix(playbook): support absence of cni_plugin variable

### DIFF
--- a/symplegma-init.yml
+++ b/symplegma-init.yml
@@ -47,7 +47,7 @@
   roles:
     - role: symplegma-flannel
       tags: flannel
-      when: cni_plugin == "flannel"
+      when: cni_plugin is defined and cni_plugin == "flannel"
 
 - hosts: win_node
   vars_files:

--- a/symplegma-upgrade.yml
+++ b/symplegma-upgrade.yml
@@ -50,7 +50,7 @@
   roles:
     - role: symplegma-flannel
       tags: flannel
-      when: cni_plugin == "flannel"
+      when: cni_plugin is defined and cni_plugin == "flannel"
 
 - hosts: win_node
   serial: 1


### PR DESCRIPTION
If no `cni_plugin` variable is defined in the inventory the playbook fails.

I change this behavior to skip the role in with the absence of variable